### PR TITLE
Fix for issue #62 and also for frame skipping

### DIFF
--- a/Recorder.cs
+++ b/Recorder.cs
@@ -215,13 +215,17 @@ class Recorder
         // the single file can be expanded into multiple (when FS performance is less needed) for ffmpeg
         Task.Run(() =>
         {
+            //Ignore after stop has been requested.
+            if (captureTimerDelegate == null)
+                return;
+
             var bmp = Capture();
             int frame = Interlocked.Increment(ref _frames);
+            string outputPath = Path.Combine(tempPath, "_" + frame + imageExtension);
 
-            string path = Path.Combine(tempPath, "_" + frame + imageExtension);
-            Debug.Assert(!File.Exists(path));
+            Debug.Assert(!File.Exists(outputPath));
 
-            bmp.Save(path, imageFormat);
+            bmp.Save(outputPath, imageFormat);
             bmp.Dispose();
         });
     }


### PR DESCRIPTION
### **Cause for issue #62:**
When the computer is unable to process at the desired framerate the Task.Run() exceeds the avaliable threads in the threadpool, which generates a giant task queue. This queue keeps running after stop have been requested and the images have been collected for the frame edit screen.

### **Fix:**
 Leaving the Capture() outside the Task.Run(), caps frame generation to the computer's performance which would solve this problem, but the capture was moved inside the Task.Run in the "Stutter reducer" (04cf3a15c254f8bbdfbb6b3b6509adaee8abb43f) commit (which is weird, maybe it was related to the frame skipping issue?). 
Anyway, another solution is to ignore tasks running after que stop have been requested to prevent unwanted frames from rendering.

### **Frame Skipping:**
Using Interlocked.Increment on the frame count prevents race condition from multiple parallel tasks running, therefore preventing frames from being overwritten or skipped.